### PR TITLE
Feature: Make service blueprint names configurable via environment va…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,13 @@ X_GITHUB_TOKEN=ghp_your_token_here
 
 # Batch size for onboarding metrics processing (default: 3)
 # ONBOARDING_BATCH_SIZE=3
+
+# =============================================================================
+# Port Blueprint Configuration (Optional)
+# =============================================================================
+
+# Target blueprint for service metrics (default: service)
+# PORT_SERVICE_BLUEPRINT=service
+
+# Target blueprint for time-series metrics (default: serviceMetrics)
+# PORT_SERVICE_METRICS_BLUEPRINT=serviceMetrics

--- a/src/env.ts
+++ b/src/env.ts
@@ -147,3 +147,24 @@ export function getCoderEnv(): CoderEnv {
     organizationId: env.CODER_ORGANIZATION_ID,
   };
 }
+
+export type PortBlueprintEnv = {
+  serviceBlueprint: string;
+  serviceMetricsBlueprint: string;
+};
+
+export function getPortBlueprintEnv(): PortBlueprintEnv {
+  const env = cleanEnv(
+    process.env,
+    {
+      PORT_SERVICE_BLUEPRINT: str({ default: "service" }),
+      PORT_SERVICE_METRICS_BLUEPRINT: str({ default: "serviceMetrics" }),
+    },
+    { reporter: throwReporter },
+  );
+
+  return {
+    serviceBlueprint: env.PORT_SERVICE_BLUEPRINT,
+    serviceMetricsBlueprint: env.PORT_SERVICE_METRICS_BLUEPRINT,
+  };
+}

--- a/src/github/service_aggregated_metrics.ts
+++ b/src/github/service_aggregated_metrics.ts
@@ -17,6 +17,11 @@ import {
   calculateContributionStandardDeviation,
   fetchRepositoryPRs,
 } from "./service_metrics";
+import { getPortBlueprintEnv } from "../env";
+
+export function getServiceMetricsBlueprintName(): string {
+  return getPortBlueprintEnv().serviceMetricsBlueprint;
+}
 
 export const SERVICE_METRICS_BLUEPRINT = {
   identifier: "serviceMetrics",
@@ -254,7 +259,7 @@ export async function storeServiceMetricsEntity(
   entity: ServiceMetricsEntity,
 ): Promise<void> {
   try {
-    await upsertEntities(SERVICE_METRICS_BLUEPRINT.identifier, [entity]);
+    await upsertEntities(getServiceMetricsBlueprintName(), [entity]);
     console.log(`Successfully stored service metrics entity: ${entity.title}`);
   } catch (error) {
     console.error(
@@ -377,7 +382,7 @@ export async function storeServiceMetricsEntities(
       `Storing ${entities.length} service metrics entities using bulk ingestion...`,
     );
     const results = await upsertEntitiesInBatches(
-      SERVICE_METRICS_BLUEPRINT.identifier,
+      getServiceMetricsBlueprintName(),
       entities,
     );
 

--- a/src/github/service_metrics.ts
+++ b/src/github/service_metrics.ts
@@ -14,8 +14,13 @@ import {
   CONCURRENCY_LIMITS,
 } from "./utils";
 import type { PortEntity } from "../clients/port/types";
+import { getPortBlueprintEnv } from "../env";
 
 export const BLUEPRINT_NAME = "service";
+
+export function getServiceBlueprintName(): string {
+  return getPortBlueprintEnv().serviceBlueprint;
+}
 export interface ServiceMetrics {
   repoId: string;
   repoName: string;
@@ -446,7 +451,10 @@ export async function storeServiceMetricsEntities(
     console.log(
       `Storing ${entities.length} service metrics entities using bulk ingestion...`,
     );
-    const results = await upsertEntitiesInBatches(BLUEPRINT_NAME, entities);
+    const results = await upsertEntitiesInBatches(
+      getServiceBlueprintName(),
+      entities,
+    );
 
     // Aggregate results
     const totalSuccessful = results.reduce(


### PR DESCRIPTION
…riables

Add PORT_SERVICE_BLUEPRINT and PORT_SERVICE_METRICS_BLUEPRINT environment variables to allow customers to specify different target blueprints for service metrics. Defaults to "service" and "serviceMetrics" respectively for backwards compatibility.