### PR TITLE
fix(pr-metrics): align githubPullRequest payload with schema and dedu…

### DIFF
--- a/src/github/__tests__/pr_metrics.test.ts
+++ b/src/github/__tests__/pr_metrics.test.ts
@@ -248,6 +248,8 @@ describe("PR Metrics", () => {
             identifier: "test-repo1",
             properties: expect.objectContaining({
               pr_size: 150,
+              total_prs: 1,
+              total_merged_prs: 1,
               pr_lifetime: expect.any(Number),
               pr_pickup_time: expect.any(Number),
               pr_success_rate: 100,
@@ -311,6 +313,8 @@ describe("PR Metrics", () => {
             identifier: "test-repo1",
             properties: expect.objectContaining({
               pr_size: 0,
+              total_prs: 1,
+              total_merged_prs: 1,
               review_participation: 0,
               pr_maturity: null,
             }),

--- a/src/github/__tests__/pr_metrics.test.ts
+++ b/src/github/__tests__/pr_metrics.test.ts
@@ -245,10 +245,13 @@ describe("PR Metrics", () => {
         "githubPullRequest",
         expect.arrayContaining([
           expect.objectContaining({
-            identifier: expect.stringContaining("test-repo"),
+            identifier: "test-repo1",
             properties: expect.objectContaining({
-              total_prs: expect.any(Number),
-              total_merged_prs: expect.any(Number),
+              pr_size: 150,
+              pr_lifetime: expect.any(Number),
+              pr_pickup_time: expect.any(Number),
+              pr_success_rate: 100,
+              review_participation: 2,
             }),
             relations: {
               service: "test-repo",
@@ -305,16 +308,54 @@ describe("PR Metrics", () => {
         "githubPullRequest",
         expect.arrayContaining([
           expect.objectContaining({
-            identifier: expect.stringContaining("test-repo"),
+            identifier: "test-repo1",
             properties: expect.objectContaining({
-              total_prs: 1,
-              number_of_prs_reviewed: 0,
+              pr_size: 0,
+              review_participation: 0,
+              pr_maturity: null,
             }),
             relations: {
               service: "test-repo",
             },
           }),
         ]),
+      );
+    });
+
+    it("should dedupe entities that appear in overlapping periods", async () => {
+      const now = new Date();
+      const recentPR: PullRequestBasic = {
+        ...mockPullRequestBasic,
+        number: 7,
+        created_at: new Date(
+          now.getTime() - 10 * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+        closed_at: new Date(
+          now.getTime() - 9 * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+        merged_at: new Date(
+          now.getTime() - 9 * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+      };
+
+      mockGitHubClient.getPullRequests
+        .mockResolvedValueOnce([recentPR])
+        .mockResolvedValueOnce([]);
+      mockGitHubClient.getPullRequest.mockResolvedValue({
+        ...mockPullRequest,
+        number: 7,
+      });
+      mockGitHubClient.getPullRequestReviews.mockResolvedValue([]);
+      mockGitHubClient.getPullRequestCommits.mockResolvedValue([]);
+
+      await calculateAndStorePRMetrics([mockRepository], mockGitHubClient);
+
+      const { upsertEntitiesInBatches } = require("../../clients/port");
+      const [, entities] = upsertEntitiesInBatches.mock.calls[0];
+      const identifiers = entities.map((entity: any) => entity.identifier);
+
+      expect(identifiers.filter((id: string) => id === "test-repo7")).toHaveLength(
+        1,
       );
     });
   });

--- a/src/github/pr_metrics.ts
+++ b/src/github/pr_metrics.ts
@@ -17,6 +17,7 @@ import {
 export interface PRMetrics {
   repoId: string;
   repoName: string;
+  prNumber: number;
   pullRequestId: string;
   // PR Size: Sum(lines added + lines deleted)
   prSize: number;
@@ -141,71 +142,6 @@ export async function fetchRepositoryPRs(
   return allPRs;
 }
 
-interface AggregatedMetrics {
-  totalPRs: number;
-  totalMergedPRs: number;
-  numberOfPRsReviewed: number;
-  numberOfPRsMergedWithoutReview: number;
-  percentageOfPRsReviewed: number;
-  percentageOfPRsMergedWithoutReview: number;
-  averageTimeToFirstReview: number;
-  prSuccessRate: number;
-  contributionStandardDeviation: number;
-}
-
-function calculateAggregatedMetrics(
-  prMetrics: PRMetrics[],
-  period: number,
-): AggregatedMetrics {
-  const totalPRs = prMetrics.length;
-  const totalMergedPRs = prMetrics.filter(
-    (pr) => pr.prSuccessRate === 100,
-  ).length;
-  const numberOfPRsReviewed = prMetrics.filter(
-    (pr) => pr.reviewParticipation > 0,
-  ).length;
-  const numberOfPRsMergedWithoutReview = totalMergedPRs - numberOfPRsReviewed;
-
-  const percentageOfPRsReviewed =
-    totalPRs > 0 ? (numberOfPRsReviewed / totalPRs) * 100 : 0;
-  const percentageOfPRsMergedWithoutReview =
-    totalMergedPRs > 0
-      ? (numberOfPRsMergedWithoutReview / totalMergedPRs) * 100
-      : 0;
-
-  const validPickupTimes = prMetrics
-    .filter((pr) => pr.prPickupTime !== null)
-    .map((pr) => pr.prPickupTime!);
-  const averageTimeToFirstReview =
-    validPickupTimes.length > 0
-      ? validPickupTimes.reduce((sum, time) => sum + time, 0) /
-        validPickupTimes.length
-      : 0;
-
-  const prSuccessRate = totalPRs > 0 ? (totalMergedPRs / totalPRs) * 100 : 0;
-
-  // Calculate standard deviation of contributions (PR sizes)
-  const prSizes = prMetrics.map((pr) => pr.prSize);
-  const meanSize =
-    prSizes.reduce((sum, size) => sum + size, 0) / prSizes.length;
-  const variance =
-    prSizes.reduce((sum, size) => sum + (size - meanSize) ** 2, 0) /
-    prSizes.length;
-  const contributionStandardDeviation = Math.sqrt(variance);
-
-  return {
-    totalPRs,
-    totalMergedPRs,
-    numberOfPRsReviewed,
-    numberOfPRsMergedWithoutReview,
-    percentageOfPRsReviewed,
-    percentageOfPRsMergedWithoutReview,
-    averageTimeToFirstReview,
-    prSuccessRate,
-    contributionStandardDeviation,
-  };
-}
-
 export async function calculateAndStorePRMetrics(
   repos: Repository[],
   githubClient: GitHubClient,
@@ -258,6 +194,7 @@ export async function calculateAndStorePRMetrics(
         ];
 
         const repoEntities: PortEntity[] = [];
+        const seenEntityIdentifiers = new Set<string>();
 
         // Process all time periods concurrently
         const timePeriodPromises = timePeriods.map(async (period) => {
@@ -301,6 +238,7 @@ export async function calculateAndStorePRMetrics(
               const record: PRMetrics = {
                 repoId: repo.id.toString(),
                 repoName: repo.name,
+                prNumber: pr.number,
                 pullRequestId: pr.id.toString(),
                 prSize: prData.additions + prData.deletions,
                 prAdditions: prData.additions,
@@ -345,7 +283,6 @@ export async function calculateAndStorePRMetrics(
                 comments: prData.comments,
                 reviewComments: prData.review_comments,
               };
-
               return record;
             } catch (error) {
               console.error(
@@ -367,42 +304,36 @@ export async function calculateAndStorePRMetrics(
             return;
           }
 
-          // Calculate aggregated metrics for this time period
-          const aggregatedMetrics = calculateAggregatedMetrics(
-            validPRResults,
-            period,
-          );
-
-          // Create Port entity for this time period
-          const entity: PortEntity = {
-            identifier: `${repo.name}-${period}-pr-metrics`,
-            title: `${repo.name} PR Metrics (${period} days)`,
+          // Create Port entities for each PR (matches githubPullRequest schema)
+          const entities: PortEntity[] = validPRResults.map((prMetric) => ({
+            identifier: `${repo.name}${prMetric.prNumber}`,
+            title: `${repo.name} #${prMetric.prNumber}`,
             properties: {
-              period: period.toString(),
-              period_type: "daily",
-              total_prs: aggregatedMetrics.totalPRs,
-              total_merged_prs: aggregatedMetrics.totalMergedPRs,
-              number_of_prs_reviewed: aggregatedMetrics.numberOfPRsReviewed,
-              number_of_prs_merged_without_review:
-                aggregatedMetrics.numberOfPRsMergedWithoutReview,
-              percentage_of_prs_reviewed:
-                aggregatedMetrics.percentageOfPRsReviewed,
-              percentage_of_prs_merged_without_review:
-                aggregatedMetrics.percentageOfPRsMergedWithoutReview,
-              average_time_to_first_review:
-                aggregatedMetrics.averageTimeToFirstReview,
-              pr_success_rate: aggregatedMetrics.prSuccessRate,
-              contribution_standard_deviation:
-                aggregatedMetrics.contributionStandardDeviation,
-              calculated_at: new Date().toISOString(),
-              data_source: "github",
+              pr_size: prMetric.prSize,
+              pr_lifetime: prMetric.prLifetime,
+              pr_pickup_time: prMetric.prPickupTime,
+              pr_approve_time: prMetric.prApproveTime,
+              pr_merge_time: prMetric.prMergeTime,
+              pr_maturity: prMetric.prMaturity,
+              pr_success_rate: prMetric.prSuccessRate,
+              review_participation: prMetric.reviewParticipation,
+              number_of_line_changes_after_pr_is_opened:
+                prMetric.numberOfLineChangesAfterPRIsOpened,
+              number_of_commits_after_pr_is_opened:
+                prMetric.numberOfCommitsAfterPRIsOpened,
             },
             relations: {
               service: repo.name,
             },
-          };
-
-          repoEntities.push(entity);
+          }));
+          const uniqueEntities = entities.filter((entity) => {
+            if (!entity.identifier || seenEntityIdentifiers.has(entity.identifier)) {
+              return false;
+            }
+            seenEntityIdentifiers.add(entity.identifier);
+            return true;
+          });
+          repoEntities.push(...uniqueEntities);
         });
 
         await Promise.all(timePeriodPromises);
@@ -479,35 +410,33 @@ export async function storePRMetricsEntities(
       entities,
     );
 
-    // Aggregate results - check both entities array and errors array
-    const totalSuccessful = results.reduce(
+    // Aggregate results:
+    // - `created=true` => newly created entities
+    // - `created=false` with no API error => updated entities (still successful upserts)
+    const totalCreated = results.reduce(
       (sum, result) => sum + result.entities.filter((r) => r.created).length,
       0,
     );
-    const totalFailed = results.reduce((sum, result) => {
-      const failedFromEntities = result.entities.filter(
-        (r) => !r.created,
-      ).length;
-      const failedFromErrors = result.errors ? result.errors.length : 0;
-      return sum + failedFromEntities + failedFromErrors;
-    }, 0);
+    const totalProcessed = results.reduce(
+      (sum, result) => sum + result.entities.length,
+      0,
+    );
+    const totalUpdated = totalProcessed - totalCreated;
+    const totalFailed = results.reduce(
+      (sum, result) => sum + (result.errors ? result.errors.length : 0),
+      0,
+    );
 
     console.log(
-      `Bulk ingestion completed: ${totalSuccessful} successful, ${totalFailed} failed`,
+      `Bulk ingestion completed: ${totalCreated} created, ${totalUpdated} updated, ${totalFailed} failed`,
     );
 
     if (totalFailed > 0) {
-      // Collect all failed entities from both sources
-      const allFailed = results.flatMap((result) => {
-        const failedFromEntities = result.entities.filter((r) => !r.created);
-        const failedFromErrors = result.errors || [];
-        return [...failedFromEntities, ...failedFromErrors];
-      });
-
-      const failedIdentifiers = allFailed.map((r) => r.identifier);
+      const failedIdentifiers = results.flatMap((result) =>
+        (result.errors || []).map((error) => error.identifier),
+      );
       console.warn(`Failed entities: ${failedIdentifiers.join(", ")}`);
 
-      // Log detailed error information
       const errors = results.flatMap((result) => result.errors || []);
       if (errors.length > 0) {
         console.warn("Detailed error information:");

--- a/src/github/pr_metrics.ts
+++ b/src/github/pr_metrics.ts
@@ -184,6 +184,8 @@ export async function calculateAndStorePRMetrics(
         console.log(
           `  Found ${allPRs.length} PRs in the last ${maxPeriod} days`,
         );
+        const repoTotalPRs = allPRs.length;
+        const repoTotalMergedPRs = allPRs.filter((pr) => !!pr.merged_at).length;
 
         // Process each time period by filtering the already-fetched data
         const timePeriods: TimePeriod[] = [
@@ -310,6 +312,8 @@ export async function calculateAndStorePRMetrics(
             title: `${repo.name} #${prMetric.prNumber}`,
             properties: {
               pr_size: prMetric.prSize,
+              total_prs: repoTotalPRs,
+              total_merged_prs: repoTotalMergedPRs,
               pr_lifetime: prMetric.prLifetime,
               pr_pickup_time: prMetric.prPickupTime,
               pr_approve_time: prMetric.prApproveTime,


### PR DESCRIPTION
## Summary
- Fixes pr-metrics ingestion to send per-PR entities to githubPullRequest instead of period-aggregate properties.
- Maps payload properties to the PR blueprint schema (including pr_size), which restores PR size population in Port.
- Dedupes PR entities across overlapping windows (30d/90d) to avoid duplicate identifier collisions.
- Updates bulk ingest result accounting to treat created: false as updates (not failures) unless API errors are present.
- Updates pr_metrics tests to validate PR-level property mapping and adds a regression test for overlap deduplication.
## Validation
- Runtime debug logs confirmed:
  - PR size is computed and now included in payload (pr_size present).
  - Dedupe removes overlapping duplicates.
- Test command:
  - bun test src/github/__tests__/pr_metrics.test.ts
  - Result: 7 passed, 0 failed